### PR TITLE
Prevent emitting keyPressed event when using the navigation buttons - solves issue #249

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Open the overlay via a clickable element in your html template (e.g. `app.compon
     Click <a href="#" (click)="openImageOverlay()">here to open the overlay</a>
   </p>
 ```
+## Navigation
+When the overlay is shown, the keyboard can be used to navigate between the images (even when no navigational buttons are displayed on the image). The following keys are available:
+
+| key | function |
+|-----|----------|
+| Arrow Right | show next image |
+| Arrow Down | show next image |
+| Arrow Left | show previous image |
+| Arrow Up | show previous image |
+| Home | show first image |
+| End | show last image |
+| Escape | close overlay |
 
 ## Used assets
 The component is based on Angular Material and uses [Google Fonts](https://fonts.google.com/specimen/Roboto) and [Google Material Icons](https://google.github.io/material-design-icons/#icon-font-for-the-web).
@@ -162,6 +174,7 @@ Reference to an image overlay opened via the MatImageOverlay service.
 | Name  | Description |
 |---|---|
 | numberOfImages | number of images that can be displayed. |
+| keydownEvents$ | Observable that is notified by keydown events on the overlay. Navigation buttons don't get emitted. |
 
 **Methods**
 | close | |
@@ -193,12 +206,6 @@ Reference to an image overlay opened via the MatImageOverlay service.
 | Gets an observable that is notified when an image has been clicked. | |
 | *Returns* | |
 | Observable&lt;ImageClickedEvent&gt; | Observable that returns the object with data of the clicked image and the imageClickedConfiguration object from the config object. |
-
-| keydownEvents | |
-|---|--|
-| Gets an observable that is notified when keydown events are targeted on the overlay. | |
-| *Returns* | |
-| Observable&lt;number&gt; | Observable returns index of the image displayed. |
 
 ### MatImageOverlayComponent
 Component used by MatImageOverlay to display the images in the modal overlay.

--- a/projects/mat-image-overlay-demo/src/app/app.component.ts
+++ b/projects/mat-image-overlay-demo/src/app/app.component.ts
@@ -86,7 +86,7 @@ export class AppComponent {
     imageOverlayRef.afterClosed().subscribe(lastImageIndex => console.log(`imageOverlayRef: overlay closed; last index=${String(lastImageIndex)}`));
     imageOverlayRef.imageChanged().subscribe(currentImageIndex => console.log(`image changed; new index=${String(currentImageIndex)}`));
     imageOverlayRef.imageClicked().subscribe(event => this.clickHandlerForOverlayDemo(event));
-    imageOverlayRef.keydownEvents().subscribe(keyboardEvent => console.log(`button pressed; event.key=${keyboardEvent.key}`));
+    imageOverlayRef.keydownEvents$.subscribe(keyboardEvent => console.log(`button pressed; event.key=${keyboardEvent.key}`));
   }
 
   /**

--- a/projects/mat-image-overlay/README.md
+++ b/projects/mat-image-overlay/README.md
@@ -60,6 +60,18 @@ Open the overlay via a clickable element in your html template (e.g. `app.compon
     Click <a href="#" (click)="openImageOverlay()">here to open the overlay</a>
   </p>
 ```
+## Navigation
+When the overlay is shown, the keyboard can be used to navigate between the images (even when no navigational buttons are displayed on the image). The following keys are available:
+
+| key | function |
+|-----|----------|
+| Arrow Right | show next image |
+| Arrow Down | show next image |
+| Arrow Left | show previous image |
+| Arrow Up | show previous image |
+| Home | show first image |
+| End | show last image |
+| Escape | close overlay |
 
 ## Used assets
 The component is based on Angular Material and uses [Google Fonts](https://fonts.google.com/specimen/Roboto) and [Google Material Icons](https://google.github.io/material-design-icons/#icon-font-for-the-web).
@@ -162,6 +174,7 @@ Reference to an image overlay opened via the MatImageOverlay service.
 | Name  | Description |
 |---|---|
 | numberOfImages | number of images that can be displayed. |
+| keydownEvents$ | Observable that is notified by keydown events on the overlay. Navigation buttons don't get emitted. |
 
 **Methods**
 | close | |
@@ -193,12 +206,6 @@ Reference to an image overlay opened via the MatImageOverlay service.
 | Gets an observable that is notified when an image has been clicked. | |
 | *Returns* | |
 | Observable&lt;ImageClickedEvent&gt; | Observable that returns the object with data of the clicked image and the imageClickedConfiguration object from the config object. |
-
-| keydownEvents | |
-|---|--|
-| Gets an observable that is notified when keydown events are targeted on the overlay. | |
-| *Returns* | |
-| Observable&lt;number&gt; | Observable returns index of the image displayed. |
 
 ### MatImageOverlayComponent
 Component used by MatImageOverlay to display the images in the modal overlay.

--- a/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.html
+++ b/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.html
@@ -1,5 +1,5 @@
 <figure class="mat-image-overlay-wrapper" (mouseenter)="figureHovering = true" (mouseleave)="figureHovering = false" [class.hovering]="figureHovering">
-  <img #overlayImage class="mat-image-overlay-image" [src]="currentImageUrl">
+  <img #overlayImage class="mat-image-overlay-image" [src]="currentImageUrl" (click)="onImageClicked()">
   <figcaption *ngIf="!isUndefinedOrEmpty(currentImageDescription)" class="img-description"
     [ngClass]="{'show-on-hover': descriptionDisplayStyle === elementDisplayStyle.onHover,
     'show-always': descriptionDisplayStyle === elementDisplayStyle.always,

--- a/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.html
+++ b/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.html
@@ -9,17 +9,17 @@
   </figcaption>
   <button type="button" class="mat-image-overlay-button mat-image-overlay-button-close"
     [ngClass]="{'show-on-hover': overlayButtonsStyle === elementDisplayStyle.onHover, 'show-always': overlayButtonsStyle === elementDisplayStyle.always}"
-    (click)="onClose()" aria-hidden="false" aria-label="close overlay">
+    (click)="btnClose()" aria-hidden="false" aria-label="close overlay">
     <mat-icon svgIcon="close"></mat-icon>
   </button>
   <button type="button" *ngIf="!firstImage" class="mat-image-overlay-button mat-image-overlay-button-left"
     [ngClass]="{'show-on-hover': overlayButtonsStyle === elementDisplayStyle.onHover, 'show-always': overlayButtonsStyle === elementDisplayStyle.always}"
-    (click)="gotoPreviousImage()" aria-hidden="false" aria-label="previous image">
+    (click)="btnPreviousImage()" aria-hidden="false" aria-label="previous image">
      <mat-icon svgIcon="arrow_back_ios"></mat-icon>
   </button>
   <button type="button" *ngIf="!lastImage" class="mat-image-overlay-button mat-image-overlay-button-right"
     [ngClass]="{'show-on-hover': overlayButtonsStyle === elementDisplayStyle.onHover, 'show-always': overlayButtonsStyle === elementDisplayStyle.always}"
-    (click)="gotoNextImage()" aria-hidden="false" aria-label="next image">
+    (click)="btnNextImage()" aria-hidden="false" aria-label="next image">
     <mat-icon svgIcon="arrow_forward_ios"></mat-icon>
   </button>
 </figure>

--- a/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
+++ b/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
@@ -184,6 +184,21 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
     return (text === undefined) || (text.length === 0);
   }
 
+  protected btnNextImage() {
+    this.gotoNextImage();
+    return false;
+  }
+
+  protected btnPreviousImage() {
+    this.gotoPreviousImage();
+    return false;
+  }
+
+  protected btnClose() {
+    this.onClose();
+    return false;
+  }
+
   /**
    * Update state of flags that show, if current image is first or last
    * in list of images.

--- a/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
+++ b/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
@@ -145,8 +145,7 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
     }
 
     // Don't send keystroke back to page containing overlay
-    event.preventDefault();
-    event.stopPropagation();
+    return false;
   }
 
   public gotoNextImage(): void {

--- a/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
+++ b/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
@@ -119,7 +119,7 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
     return this.imageDetails.numberOfImages;
   }
 
-  public onClose(): void {
+  public closeOverlay(): void {
     this.stateChanged.emit({ state: ImageOverlayState.closingRequested, data: this.currentImageIndex });
   }
 
@@ -141,7 +141,7 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
         this.gotoLastImage();
         break;
       case('Escape'):
-        this.onClose();
+        this.closeOverlay();
     }
 
     // Don't send keystroke back to page containing overlay
@@ -195,7 +195,7 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
   }
 
   protected btnClose() {
-    this.onClose();
+    this.closeOverlay();
     return false;
   }
 

--- a/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
+++ b/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
@@ -65,7 +65,6 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
   protected descriptionDisplayPosition = this.elementDisplayPosition.right;
 
   private imageDetails: MatImageDetailsProvider;
-  private imageClickUnlistener: (() => void) | undefined;
   private imagedClickedAdditionalData: Record<string, unknown> = {};
 
   constructor(
@@ -99,20 +98,11 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
   }
 
   public ngAfterViewInit(): void {
-    this.imageClickUnlistener = this.renderer2.listen(this.overlayImage.nativeElement, 'click', () => {
-      const result = this.mergeRecords(this.imageDetails.imageInformation(this.currentImageIndex), this.imagedClickedAdditionalData || {});
-      this.imageClicked.emit(result);
-    });
-
     this.stateChanged.emit({ state: ImageOverlayState.opened });
   }
 
   public ngOnDestroy(): void {
     this.stateChanged.emit({ state: ImageOverlayState.closed });
-
-    if(this.imageClickUnlistener) {
-      this.imageClickUnlistener();
-    }
   }
 
   public get numberOfImages(): number {
@@ -197,6 +187,15 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
     this.closeOverlay();
     return false;
   }
+
+  /**
+   * Handle click event of image.
+   * Emit image detail information + additionalData.
+   */
+  protected onImageClicked() {
+    const result = this.mergeRecords(this.imageDetails.imageInformation(this.currentImageIndex), this.imagedClickedAdditionalData || {});
+    this.imageClicked.emit(result);
+}
 
   /**
    * Update state of flags that show, if current image is first or last

--- a/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
+++ b/projects/mat-image-overlay/src/lib/component/mat-image-overlay.component.ts
@@ -1,4 +1,16 @@
-import { AfterViewInit, Component, ElementRef, EventEmitter, HostListener, Inject, InjectionToken, OnDestroy, Renderer2, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Inject,
+  InjectionToken,
+  OnDestroy,
+  Output,
+  Renderer2,
+  ViewChild
+} from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 
@@ -43,10 +55,12 @@ export const IMAGE_OVERLAY_CONFIG_TOKEN = new InjectionToken<MatImageOverlayConf
 })
 export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
   @ViewChild('overlayImage') overlayImage!: ElementRef;
+  @Output() newItemEvent = new EventEmitter<KeyboardEvent>();
 
   public stateChanged = new EventEmitter<ImageOverlayStateEvent>();
   public imageChanged = new EventEmitter<ImageChangedEvent>();
   public imageClicked = new EventEmitter<Record<string, unknown>>();
+  public keyDown = new EventEmitter<KeyboardEvent>();
   public currentImageIndex = 0;
 
   // Property is needed for MatImageOverlayHarness
@@ -132,6 +146,9 @@ export class MatImageOverlayComponent implements AfterViewInit, OnDestroy {
         break;
       case('Escape'):
         this.closeOverlay();
+        break;
+      default:
+        this.keyDown.emit(event);
     }
 
     // Don't send keystroke back to page containing overlay

--- a/projects/mat-image-overlay/src/lib/mat-image-overlay-ref.ts
+++ b/projects/mat-image-overlay/src/lib/mat-image-overlay-ref.ts
@@ -14,6 +14,9 @@ export const enum MatImageOverlayState {
  * Reference to an image overlay opened via the MatImageOverlay service.
  */
 export class MatImageOverlayRef {
+  public keydownEvents$: Observable<KeyboardEvent>;
+  private readonly keydownEvents = new Subject<KeyboardEvent>();
+
   /** Subject for notifying the user that the dialog has finished opening. */
   private readonly _afterOpened = new Subject<void>();
 
@@ -89,6 +92,12 @@ export class MatImageOverlayRef {
     _componentInstance.imageClicked.subscribe(event => {
       this._imageClicked.next(event);
     });
+
+    // Emit keydown events (except for the navigation buttons)
+    this.keydownEvents$ = this.keydownEvents.asObservable();
+    _componentInstance.keyDown.subscribe((event) => {
+      this.keydownEvents.next(event);
+    });
   }
 
   public get numberOfImages(): number {
@@ -135,14 +144,6 @@ export class MatImageOverlayRef {
    */
   public imageClicked(): Observable<Record<string, unknown>> {
     return this._imageClicked;
-  }
-
-  /**
-   * Gets an observable that is notified when keydown events are targeted on the overlay.
-   * @returns observable that sends Key down events targeted on the overlay
-   */
-  public keydownEvents(): Observable<KeyboardEvent> {
-    return this._overlayRef.keydownEvents();
   }
 
   public gotoNextImage(): void {


### PR DESCRIPTION
When using the navigation buttons, the pressed key is also emitted by the keydownEvents property of the MatImageOverlayRef class. As these buttons have already been handled by the MatImageOverlay class, the key should not be emitted by keydownEvents.

This pr prevents the navigation buttons to be emitted by the keydownEvents property of the MatImageOverlayRef.

BREAKING CHANGE: the keydownEvents() method of MatImageOverlayRef is replaced by the keydownEvents$ property (an observable).