### PR TITLE
Suppress support for Angular 22.x in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,13 @@ updates:
       - dependency-name: "eslint-plugin-cypress"
         versions: ["4.x", "5.x", "6.x"]
       - dependency-name: "@angular/*"
-        versions: ["18.x", "19.x", "20.x", "21.x"]
+        versions: ["18.x", "19.x", "20.x", "21.x", "22.x"]
       - dependency-name: "@angular-devkit/build-angular"
-        versions: ["18.x", "19.x", "20.x", "21.x"]
+        versions: ["18.x", "19.x", "20.x", "21.x", "22.x"]
       - dependency-name: "@angular-eslint/*"
-        versions: ["18.x", "19.x", "20.x", "21.x"]
+        versions: ["18.x", "19.x", "20.x", "21.x", "22.x"]
       - dependency-name: "ng-packagr"
-        versions: ["18.x", "19.x", "20.x", "21.x"]
+        versions: ["18.x", "19.x", "20.x", "21.x", "22.x"]
       - dependency-name: "typescript"
         versions: ["5.5.x", "5.6.x", "5.7.x", "5.8.x", "5.9.x", "6.x"]
       - dependency-name: "zone"


### PR DESCRIPTION
we cannot update single angular packages